### PR TITLE
Update the ShareButtons usage

### DIFF
--- a/resources/views/pages/social.blade.php
+++ b/resources/views/pages/social.blade.php
@@ -1,14 +1,18 @@
 <div class="social-share">
     <span class="social-share-title pull-left text-capitalize">By {{$post->user->name}} On <strong
             class="red">{{$post->getDate()}}</strong> </span>
-    <ul class="text-center pull-right">
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->facebook() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->twitter() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->linkedin() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->telegram() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->whatsapp() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->skype() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->copylink() !!}</li>
-        <li>{!! ShareButtons::page(route('post.show', $post->slug), $post->title)->mailto() !!}</li>
-    </ul>
+            {!! ShareButtons::page(route('post.show', $post->slug), $post->title, [
+                    'block_prefix' => '<ul class="text-center pull-right">',
+                    'block_suffix' => '</ul>',
+                    'element_prefix' => '<li>',
+                    'element_suffix' => '</li>',
+               ])->facebook()
+                 ->twitter()
+                 ->linkedin()
+                 ->telegram()
+                 ->whatsapp()
+                 ->skype()
+                 ->copylink()
+                 ->mailto()
+            !!}
 </div>


### PR DESCRIPTION
Hello,

I would like to propose some changes to the usage of the ShareButtons package. You could simplify your code by just using ShareButtons only once. You could even make it less wordy by moving the styling parameters (i.e. block_prefix, block_suffix, element_prefix, element_suffix) to the configuration file. Find more information about configuration settings by following [this link](https://github.com/kudashevs/laravel-share-buttons#configuration).
